### PR TITLE
[FE][Feature] 팀원 초대 api 연결

### DIFF
--- a/src/api/@types/InviteTeam.ts
+++ b/src/api/@types/InviteTeam.ts
@@ -1,0 +1,16 @@
+export interface GetInviteTeamRequest {
+  // teamId: number;
+}
+
+export interface GetInviteTeamResponse {
+  code: number;
+  message: string;
+  data: InviteTeamData;
+}
+
+export interface InviteTeamData {
+  invitationCode: string;
+  invitationUrl: string;
+  expirationTime: string;
+  qrCodeImage: string;
+}

--- a/src/api/@types/Retrospectives.ts
+++ b/src/api/@types/Retrospectives.ts
@@ -48,7 +48,7 @@ export interface PostRetrospectivesRequest {
   userId: number;
   templateId: number;
   status: keyof TStatus;
-  thumbnail: string;
+  thumbnail: string | null;
   startDate: string;
   description: string;
 }

--- a/src/api/axiosConfig.tsx
+++ b/src/api/axiosConfig.tsx
@@ -65,7 +65,7 @@ axiosInstance.interceptors.request.use(
 
       // 헤더에 토큰 추가
       config.headers.Authorization = `Bearer ${authToken}`;
-      console.log('헤더에 토큰 추가 확인', config.headers.Authorization);
+      // console.log('헤더에 토큰 추가 확인', config.headers.Authorization);
       return config;
     } catch (err) {
       console.error('에러', err);

--- a/src/api/retrospectivesApi/getInviteTeam.tsx
+++ b/src/api/retrospectivesApi/getInviteTeam.tsx
@@ -1,0 +1,14 @@
+import { GetInviteTeamRequest, GetInviteTeamResponse } from '../@types/InviteTeam';
+import axiosInstance from '../axiosConfig';
+
+const getInviteTeam = async (teamId: GetInviteTeamRequest): Promise<GetInviteTeamResponse> => {
+  try {
+    const response = await axiosInstance.get<GetInviteTeamResponse>(`/teams/${teamId}/invitation-url`);
+    console.log('팀원 초대 호출 성공', response.data);
+    return response.data;
+  } catch (error) {
+    throw new Error('팀원 초대 호출 실패');
+  }
+};
+
+export default getInviteTeam;

--- a/src/components/createRetro/modal/CreateModal.tsx
+++ b/src/components/createRetro/modal/CreateModal.tsx
@@ -36,7 +36,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, templateId, 
     userId: 1,
     templateId: templateId || 1,
     status: Status.NOT_STARTED,
-    thumbnail: '',
+    thumbnail: null,
     startDate: '',
     description: '',
   });
@@ -51,25 +51,27 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, templateId, 
 
   const handleCreateClick = async () => {
     try {
-      // 회고 먼저 생성
+      // 회고 생성 요청 전송
       const retrospectiveResponse = await postRetrospective({
         ...requestData,
         status: Status.NOT_STARTED,
+        thumbnail: requestData.thumbnail || null, // thumbnail이 없으면 null을 전송
       });
 
-      // 이미지를 S3에 업로드
-      const imageResponse = await postImageToS3({
-        filename: requestData.thumbnail, // imageUUID를 filename으로 설정
-        method: 'PUT',
-      });
+      // thumbnail이 있는 경우에만 S3에 이미지 업로드
+      if (requestData.thumbnail) {
+        const imageResponse = await postImageToS3({
+          filename: requestData.thumbnail, // imageUUID를 filename으로 설정
+          method: 'PUT',
+        });
+        console.log('사진 S3 업로드 성공', imageResponse);
+      }
 
       console.log('회고 생성 성공', retrospectiveResponse);
-      console.log('사진 S3 업로드 성공', imageResponse);
-
-      onClose();
-      navigate('/invite');
+      onClose(); // 모달 닫기
+      navigate('/retrolist'); // 회고 목록 페이지로 이동
     } catch (error) {
-      console.error('실패', error);
+      console.error('회고 생성 실패', error);
     }
   };
 

--- a/src/components/createRetro/modal/ImageUpload.tsx
+++ b/src/components/createRetro/modal/ImageUpload.tsx
@@ -30,6 +30,9 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onChange }) => {
   const handleRemoveImage = () => {
     setImagePreview(null);
     setImageUUID(null);
+    if (onChange) {
+      onChange('', '');
+    }
   };
 
   return (

--- a/src/components/inviteTeam/InviteTeam.tsx
+++ b/src/components/inviteTeam/InviteTeam.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import QRCode from 'qrcode.react';
+import { GetInviteTeamResponse, InviteTeamData } from '@/api/@types/InviteTeam';
+import getInviteTeam from '@/api/retrospectivesApi/getInviteTeam';
+
+interface InviteTeamComponentProps {
+  teamId: number;
+}
+
+const InviteTeamComponent: React.FC<InviteTeamComponentProps> = ({ teamId }) => {
+  const [inviteData, setInviteData] = useState<InviteTeamData | null>(null);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const fetchInviteData = async () => {
+      try {
+        const response: GetInviteTeamResponse = await getInviteTeam(teamId);
+        setInviteData(response.data);
+      } catch (error) {
+        console.error(error);
+        setError('팀원 초대 get 실패');
+      }
+    };
+
+    fetchInviteData();
+  }, [teamId]); // teamId가 변경될 때마다 호출
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  if (!inviteData) {
+    return <div>로딩중...</div>;
+  }
+
+  return (
+    <div>
+      <p>초대 코드: {inviteData.invitationCode}</p>
+      <p>
+        초대 URL:{' '}
+        <a href={inviteData.invitationUrl} target="_blank" rel="noopener noreferrer">
+          {inviteData.invitationUrl}
+        </a>
+      </p>
+      <p>만료 시간: {inviteData.expirationTime}</p>
+      <QRCode value={inviteData.qrCodeImage} />
+      <p>{inviteData.qrCodeImage}</p>
+    </div>
+  );
+};
+
+export default InviteTeamComponent;


### PR DESCRIPTION
## 요약
invite team GET api 연결 완료, createRetro 사진 관련 api 요청 관련 수정 했음
<br><br>

## 작업 내용
invite team GET 요청 시 초대링크, QR image 받아오기 성공
createRetro 사진 null일 때 api 요청 관련 수정 했음
<br><br>

## 참고 사항
기존 사용자 flow는 다음과 같음
1. 회고 생성 모달에서 회고 생성 시 팀원 초대 모달 렌더링
2. revise 페이지에서 팀원 초대 버튼을 눌러야 할 때 모달 렌더링

하지만 빠른 개발 완료를 위해 2번만 구현하기로 결정되었음
1번은 ver2에서 구현 할 예정
<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #153](https://github.com/donga-it-club/past-forward-frontend/issues/153)

<br><br>
