### PR TITLE
[FE][Fix] createRetro 생성일에 따른 상태 수정 

### DIFF
--- a/src/api/@types/Retrospectives.ts
+++ b/src/api/@types/Retrospectives.ts
@@ -63,7 +63,7 @@ export interface PostRetrospectivesRequest {
   templateId: number;
   status: keyof TStatus;
   thumbnail: string | null;
-  startDate: string;
+  startDate: Date | string;
   description: string;
 }
 

--- a/src/components/createRetro/CreateButtonBox.tsx
+++ b/src/components/createRetro/CreateButtonBox.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useDisclosure } from '@chakra-ui/react';
+import { TStatus } from '@/api/@types/@asConst';
 import PersonalRetroCreateButton from '@/components/createRetro/PersonalRetroCreateButton';
 import TeamRetroCreateButton from '@/components/createRetro/TeamRetroCreateButton';
 import CreateModal from '@/components/createRetro/modal/CreateModal';
@@ -9,16 +10,19 @@ const CreateButtonBox: React.FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [templateId, setTemplateId] = useState<number | null>(null);
   const [type, setType] = useState<'TEAM' | 'PERSONAL'>('TEAM');
+  const [status, setStatus] = useState<keyof TStatus>('NOT_STARTED');
 
   const handleTeamButtonClick = () => {
     setTemplateId(1);
     setType('TEAM'); // TEAM으로 type 설정
+    setStatus('NOT_STARTED'); // 초기 상태
     onOpen();
   };
 
   const handlePersonalButtonClick = () => {
     setTemplateId(2);
     setType('PERSONAL'); // PERSONAL로 type 설정
+    setStatus('NOT_STARTED'); // 초기 상태
     onOpen();
   };
 
@@ -32,7 +36,7 @@ const CreateButtonBox: React.FC = () => {
           <PersonalRetroCreateButton />
         </S.SpacedButton>
       </S.ButtonListContainer>
-      <CreateModal isOpen={isOpen} onClose={onClose} templateId={templateId} type={type} />
+      <CreateModal isOpen={isOpen} onClose={onClose} templateId={templateId} type={type} status={status} />
     </>
   );
 };

--- a/src/components/createRetro/modal/StartDateCalender.tsx
+++ b/src/components/createRetro/modal/StartDateCalender.tsx
@@ -1,31 +1,20 @@
-import React, { useState } from 'react';
-import { ko } from 'date-fns/locale/ko';
+import React from 'react';
+import { Input } from '@chakra-ui/react';
 import 'react-datepicker/dist/react-datepicker.css';
-import * as S from '@/styles/createRetro/modal/StartDateCalendar.style';
 import '@/styles/createRetro/modal/Calendar.css';
 
 interface StartDateCalendarProps {
-  onDateChange: (dateString: string) => void;
+  onDateChange: (date: Date) => void;
 }
 
 const StartDateCalendar: React.FC<StartDateCalendarProps> = ({ onDateChange }) => {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-
-  const handleDateChange = (date: Date) => {
-    setSelectedDate(date);
-    const isoDateString = date.toISOString(); // 백엔드 request body에 보낼 날짜 타입
-    onDateChange(isoDateString);
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const dateString = event.target.value; // 사용자가 입력한 날짜 문자열
+    const selectedDate = new Date(dateString); // 문자열을 Date 객체로 변환
+    onDateChange(selectedDate); // 부모 컴포넌트로 전달
   };
 
-  return (
-    <S.DateInput
-      selected={selectedDate}
-      onChange={handleDateChange}
-      locale={ko}
-      dateFormat="yyyy-MM-dd"
-      showPopperArrow={false}
-    />
-  );
+  return <Input placeholder="회고 시작일 선택" size="md" type="date" onChange={handleChange} />;
 };
 
 export default StartDateCalendar;


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18xiHPdyZGspOqm3cnnrz1eUKaWupADGw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=aVBR6NX)
## 요약
날짜 선택에 따른 status 수정 완료
<br><br>

## 작업 내용
회고 생성시 오늘 포함 이전 날짜면 'IN_PROGRESS' 로
이후 날짜면 'NOT_STARTED'로 요청되게 수정
<br><br>

## 참고 사항
api 요청할 때의 전달하는 값과 응답 값이 다름
요청할 때는 사용자가 선택한 날짜를 iso 형식으로 변환해서 요청하는데,
응답 값은 사용자가 선택한 날짜가 아닌 현재 날짜를 반환하고 있음...
추후 수정 예정
<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #175](https://github.com/donga-it-club/past-forward-frontend/issues/175)

<br><br>
