### PR TITLE
[FE][Fix] 로그인 분기 처리 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { getCurrentUser } from 'aws-amplify/auth';
 import { RecoilRoot } from 'recoil';
@@ -20,7 +20,7 @@ interface PrivateRouteProps {
   children: ReactElement;
 }
 
-// 로그인 상태 확인, 로그인 안 되어있는데 접근하면 "/" 로 리다이렉트함
+// 로그인 상태 확인, 로그인 안 되어있는데 접근하면 "/login" 로 리다이렉트함
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
@@ -44,7 +44,7 @@ const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
     return <div>로딩 중...</div>; // 로그인 상태 확인 중
   }
 
-  return isLoggedIn ? children : <Navigate to="/" replace state={{ from: location }} />;
+  return isLoggedIn ? children : <Navigate to="/login" replace state={{ from: location.pathname }} />;
 };
 
 const App = () => {
@@ -54,12 +54,6 @@ const App = () => {
       const visited = localStorage.getItem('surveyVisited');
       return visited !== null ? visited === 'true' : false;
     };
-
-    const location = useLocation();
-
-    useEffect(() => {
-      // 추가적인 페이지 접근 로직이 필요하면 여기에 구현
-    }, [location]);
 
     // surveyVisited 값이 'true'인 경우, 홈 페이지로 리다이렉트
     if (checkSurveyVisited()) {
@@ -134,7 +128,6 @@ const App = () => {
             />
             {/* 발급 될 초대 링크 */}
             <Route path="/invitations" Component={AcceptInvite} />
-            {/* <Route path={`/invitations?invitationId=${invitationId}`} element={<AcceptInvitePage />} /> */}
           </Routes>
         </Router>
       </RecoilRoot>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1DtyCNY12PPSqfHCxY2xha9qaDi5CbUxk%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=nsye1k4)
## 요약
로그인 안 된 유저가 create 접근 시 /login 으로 이동
<br><br>

## 작업 내용
App.tsx 에서 기존 "/" 로 되어 있는 부분 "/login"으로 수정
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #114](https://github.com/donga-it-club/past-forward-frontend/issues/114)

<br><br>
