### PR TITLE
:sparkles: Feat : 회고 생성 시 필요한 필수값 안내하기

### DIFF
--- a/src/components/createRetro/CreateButtonBox.tsx
+++ b/src/components/createRetro/CreateButtonBox.tsx
@@ -13,14 +13,15 @@ const CreateButtonBox: React.FC = () => {
   const [status, setStatus] = useState<keyof TStatus>('NOT_STARTED');
 
   const handleTeamButtonClick = () => {
-    setTemplateId(1);
+    setTemplateId(1); // KPT를 초기값으로 함
     setType('TEAM'); // TEAM으로 type 설정
     setStatus('NOT_STARTED'); // 초기 상태
     onOpen();
   };
 
   const handlePersonalButtonClick = () => {
-    setTemplateId(2);
+    // setTemplateId(2); // Kudos를 초기 값으로 함
+    setTemplateId(1); // KPT를 초기값으로 함
     setType('PERSONAL'); // PERSONAL로 type 설정
     setStatus('NOT_STARTED'); // 초기 상태
     onOpen();

--- a/src/components/createRetro/modal/CreateModal.tsx
+++ b/src/components/createRetro/modal/CreateModal.tsx
@@ -55,6 +55,20 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose, templateId, 
 
   const handleCreateClick = async () => {
     try {
+      if (!requestData.title) {
+        // 회고 제목이 비어 있다면 사용자에게 알림을 표시함
+        alert('회고 제목을 입력해 주세요.');
+        return;
+      }
+
+      if (!requestData.description) {
+        // 회고 내용이 비어있다면 requestData.description에 빈칸 한 개 삽입하고 회고 생성함
+        requestData.description = ' ';
+        // 회고 내용이 비어 있다면 사용자에게 알림을 표시함
+        // alert('회고 내용을 입력하세요.');
+        return;
+      }
+
       let calculatedStatus: keyof TStatus = 'NOT_STARTED'; // 기본값은 'NOT_STARTED'로 설정
 
       // startDate 값이 오늘 이전이면 'IN_PROGRESS'로 설정

--- a/src/components/createRetro/modal/DescriptionInput.tsx
+++ b/src/components/createRetro/modal/DescriptionInput.tsx
@@ -9,7 +9,7 @@ const DescriptionInput: React.FC<DescriptionInputProps> = ({ onChange }) => {
   return (
     <>
       <Input
-        placeholder="회고에 대한 설명을 입력해주세요."
+        placeholder="회고에 대한 설명을 입력해 주세요."
         variant="flushed"
         onChange={e => onChange(e.target.value)}
       ></Input>

--- a/src/components/createRetro/modal/TitleInput.tsx
+++ b/src/components/createRetro/modal/TitleInput.tsx
@@ -5,7 +5,7 @@ const TitleInput: React.FC<{ onChange: (title: string) => void }> = ({ onChange 
   return (
     <>
       <Input
-        placeholder="Retrospect Name"
+        placeholder="Retrospect Name *"
         variant="flushed"
         onChange={e => onChange(e.target.value)}
         id="cr_writename"


### PR DESCRIPTION
## 요약
회고 생성 시 필요한 필수값 안내하기
<br><br>

## 작업 내용
- [x] 회고 제목을 입력하지 않으면 '회고 제목을 입력해 주세요' 알림 나타내기
- [x] 기본 회고 옵션을 KPT로 설정하기
- [x] 회고 설명을 입력하지 않으면, 회고 설명을 '빈 칸 1개'(스페이스 바)로 설정하기
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #257](https://github.com/donga-it-club/past-forward-frontend/issues/257)

<br><br>
