### PR TITLE
:bug: Fix: RetroList 무한 로딩 버그 해결

### DIFF
--- a/src/components/RetroList/ContentsList.tsx
+++ b/src/components/RetroList/ContentsList.tsx
@@ -120,8 +120,11 @@ const ContentList: React.FC<ContentListProps> = ({ data, viewMode, searchData, s
         setIsLoading(false);
       }
     };
-
-    filtered.forEach(item => fetchThumbnailsData(item));
+    if (filtered.length) {
+      filtered.forEach(item => fetchThumbnailsData(item));
+    } else {
+      setIsLoading(false);
+    }
   }, [data]);
 
   if (!user) return;

--- a/src/pages/RetroListPage.tsx
+++ b/src/pages/RetroListPage.tsx
@@ -32,7 +32,7 @@ const RetroListPage = () => {
 
   const [query, setQuery] = useState<GetRetrospectiveRequest>({
     page: 0,
-    size: 10,
+    size: 9,
     order: 'NEWEST',
     status: 'ALL',
     keyword: '',
@@ -160,8 +160,9 @@ const RetroListPage = () => {
   };
 
   const handleBookmarkButton = (option: boolean) => {
+    setCurrentPage(1);
     setQuery(prev => {
-      return { ...prev, isBookmarked: option };
+      return { ...prev, page: 0, isBookmarked: option };
     });
   };
 


### PR DESCRIPTION
## 요약

RetroList 무한 로딩 버그 해결
페이지네이션 관련 수정

## 작업 내용

- RetroList에서 회고 카드에 썸네일이 모두 없을 경우 로딩이 계속 되는 버그 발견
- 한페이지 기본 회고 개수 9로 설정
- 북마크 옵션 눌렀을 때 1페이지로 이동하게 설정
## 참고 사항

<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #286 ](https://github.com/donga-it-club/past-forward-frontend/issues/286)

<br><br>
