### PR TITLE
[FE][Feature] ProjectRetro 라우터 설정 변경 및 페이지 이동 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,7 @@ const App = () => {
                 }
               />
               <Route
-                path="/retrospectiveGroups"
+                path="/groups"
                 element={
                   <PrivateRoute>
                     <ProjectRetro />
@@ -123,7 +123,7 @@ const App = () => {
                 }
               />
               <Route
-                path="/retrospectiveGroups/:id"
+                path="/group-boards"
                 element={
                   <PrivateRoute>
                     <GroupBoard />

--- a/src/components/layout/parts/OtherNav.tsx
+++ b/src/components/layout/parts/OtherNav.tsx
@@ -1,3 +1,4 @@
+import { RiFolder6Fill } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import * as S from '@/styles/layout/layout.style';
 
@@ -13,6 +14,12 @@ const OtherNav = () => {
       </S.OrdinaryButton>
       <S.OrdinaryButton onClick={() => navigate('retrolist')} style={{ backgroundColor: '#37447E' }}>
         Retrospect List
+      </S.OrdinaryButton>
+      <S.OrdinaryButton onClick={() => navigate('groups')} style={{ backgroundColor: '#898ea9' }}>
+        <div style={{ display: 'flex', alignItems: 'center', padding: '0px 5px' }}>
+          <RiFolder6Fill style={{ color: 'white', marginRight: '5px' }} />
+          Project
+        </div>
       </S.OrdinaryButton>
     </S.LeftBox>
   );

--- a/src/components/layout/parts/PageSideBar.tsx
+++ b/src/components/layout/parts/PageSideBar.tsx
@@ -13,12 +13,15 @@ import {
   Flex,
 } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
+import { GetRetrospectiveGroups } from '@/api/@types/Groups';
 import { GetRetrospectiveData } from '@/api/@types/Retrospectives';
+import { queryGetRetrospectiveAllGroups } from '@/api/retroGroupsApi/getAllGroups';
 import { queryGetRetrospective } from '@/api/retrospectivesApi/getRetrospective';
 import DefaultHeader from '@/components/user/DefaultHeader';
 import UserEmail from '@/components/user/UserEmail';
 import UserNickname from '@/components/user/UserNickname';
 import UserProfileImage from '@/components/user/UserProfileImage';
+import { useSingleAndDoubleClick } from '@/hooks/useSingleAndDoubleClick';
 import { userNicknameState } from '@/recoil/user/userAtom';
 import * as S from '@/styles/layout/layout.style';
 
@@ -30,6 +33,7 @@ const PageSideBar: FC<Props> = ({ onClose }) => {
   const [userNickname, setUserNickname] = useRecoilState(userNicknameState);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [retro, setRetro] = useState<GetRetrospectiveData['data']>();
+  const [group, setGroup] = useState<GetRetrospectiveGroups['data']>({ totalCount: 0, nodes: [] });
   const navigate = useNavigate();
 
   const navigateToMy = () => {
@@ -57,6 +61,34 @@ const PageSideBar: FC<Props> = ({ onClose }) => {
     fetchRetrospective();
   }, [retro?.totalCount]);
 
+  useEffect(() => {
+    const fetchGroup = async () => {
+      try {
+        const responseData = await queryGetRetrospectiveAllGroups({
+          page: 0,
+          size: 5,
+          status: '',
+          keyword: '',
+          isBookmarked: false,
+        });
+        setGroup(responseData.data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchGroup();
+  }, []);
+
+  const callbackClick = () => {
+    void 0;
+  };
+
+  const callbackDoubleclick = () => {
+    navigate(`/groups`);
+  };
+
+  const click = useSingleAndDoubleClick(callbackClick, callbackDoubleclick);
+
   return (
     <S.SideBarBGContainer>
       <Flex justifyContent="flex-end" margin="5px">
@@ -82,7 +114,7 @@ const PageSideBar: FC<Props> = ({ onClose }) => {
       <Accordion allowMultiple color="black">
         {/* Project */}
         <AccordionItem border="1px solid gray">
-          <AccordionButton>
+          <AccordionButton onClick={click}>
             <S.MiniBox>
               <Flex alignItems="center" padding="2px 10px">
                 <AccordionIcon /> <RiFolder6Fill style={{ marginRight: '5px', color: '#111b47' }} />
@@ -90,6 +122,21 @@ const PageSideBar: FC<Props> = ({ onClose }) => {
               </Flex>
             </S.MiniBox>
           </AccordionButton>
+          {group &&
+            group.nodes.map(id => (
+              <AccordionPanel pb={4}>
+                <a
+                  id="leftside_persnalproject"
+                  href={`group-boards?id=${id.id}`}
+                  style={{ color: '#939393', textDecoration: 'none' }}
+                >
+                  <Flex alignItems="center" padding="0 20px">
+                    <PersonFill style={{ marginRight: '5px', color: '#939393' }} />
+                    {id.title}
+                  </Flex>
+                </a>
+              </AccordionPanel>
+            ))}
         </AccordionItem>
 
         {/* Personal Retro */}
@@ -181,7 +228,7 @@ const PageSideBar: FC<Props> = ({ onClose }) => {
             <AccordionButton>
               <Flex alignItems="center" padding="2px 10px">
                 <IoIosListBox style={{ marginRight: '5px' }} />
-                <a style={{ color: '#111b47', textDecoration: 'none' }}>Go to Retrospect List</a>
+                <a style={{ color: '#111b47', textDecoration: 'none' }}>Retrospect List</a>
               </Flex>
             </AccordionButton>
           </Link>

--- a/src/components/projectRetro/GroupBoardList.tsx
+++ b/src/components/projectRetro/GroupBoardList.tsx
@@ -78,8 +78,6 @@ const GroupBoardList: React.FC<GroupBoardListProps> = ({ data }) => {
     }
   }, [data]);
 
-  console.log('DATA', data);
-
   return (
     <>
       {data && data.length !== 0 ? (

--- a/src/components/projectRetro/GroupList.tsx
+++ b/src/components/projectRetro/GroupList.tsx
@@ -129,7 +129,7 @@ const GroupList: React.FC<GroupListProps> = ({ groups }) => {
             <S.InfoBox>
               <S.InnerBox>
                 <RiFolder6Fill size={20} style={{ color: '#FFE500' }} />
-                <S.TitleText onClick={() => navigate(`/retrospectiveGroups/${group.id}`)}>{group.title}</S.TitleText>
+                <S.TitleText onClick={() => navigate(`/group-boards?id=${group.id}`)}>{group.title}</S.TitleText>
                 <MdOutlineMoreHoriz
                   size={25}
                   style={{ alignItems: 'start', justifySelf: 'end', cursor: 'pointer', marginLeft: 'auto' }}

--- a/src/hooks/useSingleAndDoubleClick.tsx
+++ b/src/hooks/useSingleAndDoubleClick.tsx
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+export function useSingleAndDoubleClick(
+  actionSimpleClick: () => void,
+  actionDoubleClick: () => void,
+  delay: number = 250,
+): () => void {
+  const [click, setClick] = useState<number>(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (click === 1) actionSimpleClick();
+      setClick(0);
+    }, delay);
+
+    if (click === 2) actionDoubleClick();
+
+    return () => clearTimeout(timer);
+  }, [click, actionSimpleClick, actionDoubleClick, delay]);
+
+  return () => setClick(prev => prev + 1);
+}

--- a/src/pages/GroupBoardPage.tsx
+++ b/src/pages/GroupBoardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { RiFolder6Fill } from 'react-icons/ri';
-import { useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import {
   GetRetrospectiveGroupRequest,
   GetRetrospectiveGroupResponse,
@@ -13,12 +13,9 @@ import * as S from '@/styles/projectRetro/GroupBoard.styles';
 
 const GroupBoard = () => {
   const toast = useCustomToast();
-  const { id } = useParams();
-  if (!id) {
-    toast.error('다시 접속해주시기 바랍니다.');
-    throw new Error('ID is undefined');
-  }
-  const groupId: number = parseInt(id);
+  const { search } = useLocation();
+  const query = search.split(/[=,&]/);
+  const groupId = Number(query[1]);
 
   const [groupData, setGroupData] = useState<GetRetrospectiveGroupResponse['data'] | null>(null);
   const [groupBoardData, setGroupBoardData] = useState<GetRetrospectiveGroupNodes[] | null>(null);
@@ -44,8 +41,6 @@ const GroupBoard = () => {
       setGroupBoardData(groupData.retrospectives);
     }
   }, [groupData]);
-
-  console.log('groupBoardData', groupBoardData);
 
   return (
     <S.Container>


### PR DESCRIPTION
## 요약
ProjectRetro 라우터 설정 변경 및 페이지 이동 설정

## 작업 내용
1. 라우터 설정 변경
- 변수 url 쿼리 처리
- retrospectiveGroups -> groups
- retrospectiveGroups/${id} -> group-board?id=${id}
<br><br>
2. 이동 버튼 설정
- 사이드바 클릭 -> 해당 프로젝트 표시하기
- 사이드바 더블 클릭 -> 그룹화 페이지로 이동
- 내비게이션 그룹화 이동 버튼 제작
- Go to Retrospect List -> Retrospect List 사이드바 글자 수정

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #327 ](https://github.com/donga-it-club/past-forward-frontend/issues/327)

<br><br>
