### PR TITLE
[FE][Fix] ProjectRetro 회고 관리하기 페이지 - 전체 해제 오류 수정

### DIFF
--- a/src/components/projectRetro/ManageModal.tsx
+++ b/src/components/projectRetro/ManageModal.tsx
@@ -74,7 +74,7 @@ const ManageModal: React.FC<ManageModalProps> = ({ groupId, data, isClose }) => 
   }, [retro?.totalCount]);
 
   const handlePutBoard = async () => {
-    if (requestData.length === 0) {
+    if (requestData.length === 0 && checkedRetroId.length === 0) {
       isClose();
     } else {
       try {


### PR DESCRIPTION
## 요약

ProjectRetro 회고 관리하기 페이지 - 전체 해제 오류 수정

## 작업 내용

기존에 그룹 내 회고가 0개이고, 새로 추가하는 회고가 없을 시에만 요청을 보내지 않도록 수정

## 참고 사항

<br><br>

## 관련 이슈

 <!-- github 이슈번호  -->

- 이슈번호 [issue #356](https://github.com/donga-it-club/past-forward-frontend/issues/356)

<br><br>
